### PR TITLE
ref(pkg/controller/utils.go,pkg/sshd/sshd.go): send public key fingerprint to the controller

### DIFF
--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -1,0 +1,50 @@
+package controller
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	testingClientKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAvziJnoiaaVyUGPnyqVC49XLzNRS+TPW63Nw4qovCG8lVbxKG
+DIHC64tJrCDiZd0ppEhY+RQDGaPwrMInHnV8IwdS1wX22UTRuXA/oXmHcIxO2zmU
+nrjFDlpKm2o+2Xd167ifdV9AiqNBtquO0M882RaGy99LbNPcl9ugAnxo5DVI1jES
+l5vYqtiOAnRSvmJn2c+hkJfKXryH7hU4y+blDK5Vz44eSsC7bgG3ZbKfKGR9mlf2
+ozVlzMNi2ACZ58vDBxn5WVLb1bPV1LHpicJ00fU3TDRnK3MkwvvAnqp78bNzi+ou
+YIAwYSZ41iHNd596LQJchr1vs3Fo8qbgYaLY8wIDAQABAoIBAEJgQL0ME/Vw0mOd
+F5OYVqu0vCF30trqDXQu6Wih3L5Cc+p7Vpau0Fds4STjwVK0o4jIKEJFpRHYa2m8
+d1HGXFHYb/P9uQMQNXCWOzA0/EOgIJtOcH1sC9MAmpc6GRjps8AgNRHL/55gLyZW
+hNuMpEWC4UWRfCAJpq/7554VS1+zWK0vy1GszikROjsZnopLTshMV+/7217tSk4O
+1GY9ucNJX5iX3M83pmBOJX0ce8fqxeNnAdQIaAtp+ytm5TRzyaQtTjMlq0oqP8+7
+Zx9aZKT11IpbOKBSIc6twRArlV1dT9kEI15zS9hfbWuvguB0zuhbhejS4wmZb9Tt
+X8rGL4ECgYEA+MZcRzxpBKL+VNuQ4iSwF3RUYL1FIglJV7AM8UdM2hiNeiKidhD5
+kmNXVf9C6XWg3OIHCno7HetBo0WZIPmOQMy4CDGC2bWEnQN+/bf3xsKzbECCLtH+
+DALXSztihGGiY2zSoOCwTe7WZjGaF9s4C2rVkhsU/9di4qbapGTaWMECgYEAxMZD
+c/sVTTT+/thdcLbBDhAfy6RMQwAy/1IPxNVR4C4O+l/rspbKxvV7JyaErP66g871
+dBwrOGMfEsYoOOsUBFaj2/jJZdHvQj9jY/kdsfMBivHzkWEFte09NROOThbq+sgX
+5bIPwS+IcVCgcA4We+aBv+rYKdvk05RJ8owPSrMCgYBjz4H6erxPxe1wsl8gvEOC
+RYQNBCMWks9ARTwMGeU1o6AvnnG8GPdoyj6iHDYGYNFXjb/xbjUFvfupvCTB3B48
+1WYIs4SiQHeiX2K1/PeGYVuHVSJmEo5w1zr1zi+qmVmDtoeTUFKsEeUnP0NpyuRj
+gEuLwR3dv9bGxNb4GhaYgQKBgDNQCFL8TMe/ZCeMwIEeByXlqoTuKTznlmTiP15y
+ylENcbZ0wP/nNqW/aggBkWOTYYvxsiw/FD42CupYZjDBjIy9EynPrKUyo5PA9+gg
+FFBNMD/NbFii1lxkqytmGBvg+hG/kAvD7TvRa2ExR0UxR0e0Cm3Dje8MepV5+/aV
+837lAoGBAPcvnrDFWKUy8dlrw05+9esiuZgCrCzZPw5xIxhrnRPcBOBl+QdpMscP
+eWVutcVy5Frxl5tTf71WK/YhGPgWBt/CQz73Bf1+CX80CeApWWAqiAr240NED5a0
+dBAFNBWp8IdHnQmdp9HKvxEXSK+RgOzPNLrpaRv+FPuiD6OtvhmD
+-----END RSA PRIVATE KEY-----`
+	testingClientFingerprint = `78:b9:21:20:1a:ed:e6:10:05:35:47:da:d4:1f:b6:73`
+)
+
+func sshTestingClientKey() (ssh.Signer, error) {
+	return ssh.ParsePrivateKey([]byte(testingClientKey))
+}
+
+func TestFingerprint(t *testing.T) {
+	key, _ := sshTestingClientKey()
+	fp := fingerprint(key.PublicKey())
+	if fp != testingClientFingerprint {
+		t.Errorf("Expected fingerprint %s to match %s.", fp, testingClientFingerprint)
+	}
+}

--- a/pkg/sshd/server_test.go
+++ b/pkg/sshd/server_test.go
@@ -77,10 +77,6 @@ func sshTestingHostKey() (ssh.Signer, error) {
 	return ssh.ParsePrivateKey([]byte(testingHostKey))
 }
 
-func sshTestingClientKey() (ssh.Signer, error) {
-	return ssh.ParsePrivateKey([]byte(testingClientKey))
-}
-
 func runServer(config *ssh.ServerConfig, t *testing.T) cookoo.Context {
 	reg, router, cxt := cookoo.Cookoo()
 	cxt.Put(ServerConfig, config)
@@ -158,34 +154,6 @@ v3+ZZfZMlci4pxBtXqrnoyj4uUoqZtR3ENLz53SN1i0vpT7DtC6gMnEF1UWiaoJ6
 6mGH5/bxCg9wpV7qpqR0EbFM/dhQFZmmnirOS8x+00hJvc1HFiuN/A==
 -----END RSA PRIVATE KEY-----
 `
-	testingClientKey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAvziJnoiaaVyUGPnyqVC49XLzNRS+TPW63Nw4qovCG8lVbxKG
-DIHC64tJrCDiZd0ppEhY+RQDGaPwrMInHnV8IwdS1wX22UTRuXA/oXmHcIxO2zmU
-nrjFDlpKm2o+2Xd167ifdV9AiqNBtquO0M882RaGy99LbNPcl9ugAnxo5DVI1jES
-l5vYqtiOAnRSvmJn2c+hkJfKXryH7hU4y+blDK5Vz44eSsC7bgG3ZbKfKGR9mlf2
-ozVlzMNi2ACZ58vDBxn5WVLb1bPV1LHpicJ00fU3TDRnK3MkwvvAnqp78bNzi+ou
-YIAwYSZ41iHNd596LQJchr1vs3Fo8qbgYaLY8wIDAQABAoIBAEJgQL0ME/Vw0mOd
-F5OYVqu0vCF30trqDXQu6Wih3L5Cc+p7Vpau0Fds4STjwVK0o4jIKEJFpRHYa2m8
-d1HGXFHYb/P9uQMQNXCWOzA0/EOgIJtOcH1sC9MAmpc6GRjps8AgNRHL/55gLyZW
-hNuMpEWC4UWRfCAJpq/7554VS1+zWK0vy1GszikROjsZnopLTshMV+/7217tSk4O
-1GY9ucNJX5iX3M83pmBOJX0ce8fqxeNnAdQIaAtp+ytm5TRzyaQtTjMlq0oqP8+7
-Zx9aZKT11IpbOKBSIc6twRArlV1dT9kEI15zS9hfbWuvguB0zuhbhejS4wmZb9Tt
-X8rGL4ECgYEA+MZcRzxpBKL+VNuQ4iSwF3RUYL1FIglJV7AM8UdM2hiNeiKidhD5
-kmNXVf9C6XWg3OIHCno7HetBo0WZIPmOQMy4CDGC2bWEnQN+/bf3xsKzbECCLtH+
-DALXSztihGGiY2zSoOCwTe7WZjGaF9s4C2rVkhsU/9di4qbapGTaWMECgYEAxMZD
-c/sVTTT+/thdcLbBDhAfy6RMQwAy/1IPxNVR4C4O+l/rspbKxvV7JyaErP66g871
-dBwrOGMfEsYoOOsUBFaj2/jJZdHvQj9jY/kdsfMBivHzkWEFte09NROOThbq+sgX
-5bIPwS+IcVCgcA4We+aBv+rYKdvk05RJ8owPSrMCgYBjz4H6erxPxe1wsl8gvEOC
-RYQNBCMWks9ARTwMGeU1o6AvnnG8GPdoyj6iHDYGYNFXjb/xbjUFvfupvCTB3B48
-1WYIs4SiQHeiX2K1/PeGYVuHVSJmEo5w1zr1zi+qmVmDtoeTUFKsEeUnP0NpyuRj
-gEuLwR3dv9bGxNb4GhaYgQKBgDNQCFL8TMe/ZCeMwIEeByXlqoTuKTznlmTiP15y
-ylENcbZ0wP/nNqW/aggBkWOTYYvxsiw/FD42CupYZjDBjIy9EynPrKUyo5PA9+gg
-FFBNMD/NbFii1lxkqytmGBvg+hG/kAvD7TvRa2ExR0UxR0e0Cm3Dje8MepV5+/aV
-837lAoGBAPcvnrDFWKUy8dlrw05+9esiuZgCrCzZPw5xIxhrnRPcBOBl+QdpMscP
-eWVutcVy5Frxl5tTf71WK/YhGPgWBt/CQz73Bf1+CX80CeApWWAqiAr240NED5a0
-dBAFNBWp8IdHnQmdp9HKvxEXSK+RgOzPNLrpaRv+FPuiD6OtvhmD
------END RSA PRIVATE KEY-----`
 
-	testingClientPubKey      = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/OImeiJppXJQY+fKpULj1cvM1FL5M9brc3Diqi8IbyVVvEoYMgcLri0msIOJl3SmkSFj5FAMZo/CswicedXwjB1LXBfbZRNG5cD+heYdwjE7bOZSeuMUOWkqbaj7Zd3XruJ91X0CKo0G2q47QzzzZFobL30ts09yX26ACfGjkNUjWMRKXm9iq2I4CdFK+YmfZz6GQl8pevIfuFTjL5uUMrlXPjh5KwLtuAbdlsp8oZH2aV/ajNWXMw2LYAJnny8MHGflZUtvVs9XUsemJwnTR9TdMNGcrcyTC+8Ceqnvxs3OL6i5ggDBhJnjWIc13n3otAlyGvW+zcWjypuBhotjz donotuse`
-	testingClientFingerprint = `78:b9:21:20:1a:ed:e6:10:05:35:47:da:d4:1f:b6:73`
+	testingClientPubKey = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/OImeiJppXJQY+fKpULj1cvM1FL5M9brc3Diqi8IbyVVvEoYMgcLri0msIOJl3SmkSFj5FAMZo/CswicedXwjB1LXBfbZRNG5cD+heYdwjE7bOZSeuMUOWkqbaj7Zd3XruJ91X0CKo0G2q47QzzzZFobL30ts09yX26ACfGjkNUjWMRKXm9iq2I4CdFK+YmfZz6GQl8pevIfuFTjL5uUMrlXPjh5KwLtuAbdlsp8oZH2aV/ajNWXMw2LYAJnny8MHGflZUtvVs9XUsemJwnTR9TdMNGcrcyTC+8Ceqnvxs3OL6i5ggDBhJnjWIc13n3otAlyGvW+zcWjypuBhotjz donotuse`
 )

--- a/pkg/sshd/sshd.go
+++ b/pkg/sshd/sshd.go
@@ -71,15 +71,12 @@ func ParseHostKeys(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Inte
 func AuthKey(c cookoo.Context, p *cookoo.Params) (interface{}, cookoo.Interrupt) {
 	log.Debugf(c, "Starting ssh authentication")
 	key := p.Get("key", nil).(ssh.PublicKey)
-
-	strKey := string(ssh.MarshalAuthorizedKey(key))
-	log.Debugf(c, "Checking auth for user key %v", strKey)
-	userInfo, err := controller.UserInfoFromKey(strKey)
+	userInfo, err := controller.UserInfoFromKey(key)
 	if err != nil {
 		return nil, err
 	}
 
-	userInfo.Key = strKey
+	userInfo.Key = string(ssh.MarshalAuthorizedKey(key))
 	c.Put("userinfo", userInfo)
 
 	log.Infof(c, "Key accepted for user %s.", userInfo.Username)


### PR DESCRIPTION
Instead of encoded public key. This avoids long URLs, and the need to encode the public key at all.

@aledbf: @helgi has changed the controller to accept fingerprints in the path of the `/v2/hooks/key` API call, so this change reflects the builder side of things. I've opened this PR against your `remove-etcd` branch, and I believe that this will need to be merged before deis/builder#148 can be merged.
